### PR TITLE
Add ability to define which directory to deploy to

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ deploy:
   type: heroku
   repo: <repository url>
   message: [message]
+  directory: [directory]
 ```
 
 - **repo**: Repository URL
 - **message**: Commit message. The default commit message is `Site updated: {{ now('YYYY-MM-DD HH:mm:ss') }}`.
+- **directory**: Directory. The default directory is `public`.
 
 ## Reset
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -20,7 +20,7 @@ module.exports = function(args) {
   var baseDir = this.base_dir;
   var publicDir = this.public_dir;
   var deployDir = pathFn.join(baseDir, '.deploy_heroku');
-  var deployPubDir = pathFn.join(deployDir, 'public');
+  var deployPubDir = pathFn.join(deployDir, args.directory || 'public');
   var log = this.log;
   var message = commitMessage(args);
   var verbose = !args.silent;
@@ -33,7 +33,8 @@ module.exports = function(args) {
     help += '  deploy:\n';
     help += '    type: heroku\n';
     help += '    repo: <repository url>\n';
-    help += '    message: [message]\n\n';
+    help += '    message: [message]\n';
+    help += '    directory: [directory]\n\n';
     help += 'For more help, you can check the docs: ' + chalk.underline('http://hexo.io/docs/deployment.html');
 
     console.log(help);


### PR DESCRIPTION
There are situations where one might want to deploy to a different directory other than `public`. This pull request keeps the current behavior as the default while allowing more control to the end user.